### PR TITLE
Fix syntax in test.sh, README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Tests are written using the [official test](https://github.com/ash-shell/test) m
 You can run tests by running this command, after Yaml-Parse is installed:
 
 ```sh
-ash test yamlparse
+ash test yaml-parse
 ```
 
 ## Credits

--- a/test.sh
+++ b/test.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-local file="$Ash__ACTIVE_MODULE_DIRECTORY/extra/example.yaml"
-local prefix="YamlParse_output_"
+declare file="$Ash__ACTIVE_MODULE_DIRECTORY/extra/example.yaml"
+declare prefix="YamlParse_output_"
 eval $(YamlParse__parse "$file" "$prefix")
 
 #################################################


### PR DESCRIPTION
I was not able to use yaml-parse without these tweaks.
